### PR TITLE
move splashscreen to index route (switch navigator)

### DIFF
--- a/src/pages/SplashScreen.tsx
+++ b/src/pages/SplashScreen.tsx
@@ -11,12 +11,19 @@ interface IProps {
 export default class SplashScreen extends Component<IProps> {
   public componentDidMount() {
     // TODO: check login credentials
-    setTimeout(() => this.props.navigation.navigate("CommunityList"), 1000)
+    setTimeout(() => this.props.navigation.navigate("Welcome"), 1000)
   }
 
   public render() {
     return (
-      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: "white" }}>
+      <View
+        style={{
+          flex: 1,
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "white",
+        }}
+      >
         <Image source={SplashImage} />
       </View>
     )

--- a/src/routes/auth/index.tsx
+++ b/src/routes/auth/index.tsx
@@ -2,11 +2,9 @@ import { createStackNavigator } from "react-navigation"
 import Login from "../../pages/auth/Login"
 import Register from "../../pages/auth/Register"
 import Welcome from "../../pages/auth/Welcome"
-import SplashScreen from "../../pages/SplashScreen"
 
 export default createStackNavigator(
   {
-    SplashScreen,
     Welcome,
     Login,
     Register,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,9 +1,11 @@
 import { createAppContainer, createSwitchNavigator } from "react-navigation"
+import SplashScreen from "../pages/SplashScreen"
 import authRoutes from "./auth"
 import mainRoutes from "./main"
 
 export default createAppContainer(
   createSwitchNavigator({
+    SplashScreen,
     authRoutes,
     mainRoutes,
   }),


### PR DESCRIPTION
After splashscreen disappear, we can't go back to splashscreen again, so we must put splashscreen route to switch navigator of index route